### PR TITLE
bug fix: increment cnt in retryuploadFailed dir

### DIFF
--- a/common_helper.go
+++ b/common_helper.go
@@ -158,7 +158,7 @@ func getDeveloperInfo(tenantId string, apiKey string) developerInfo {
 				" and apiKey = %s", tenantId, apiKey)
 			// Incase of unknown apiKey~tenantId,
 			// try to refresh the cache ansynchronously incase an update was missed or delayed
-			go createTenantCache()
+			go createDeveloperInfoCache()
 			return developerInfo{}
 		} else {
 			return devInfo

--- a/upload_manager.go
+++ b/upload_manager.go
@@ -104,6 +104,7 @@ func retryFailedUploads() {
 				log.Errorf("Cannot move directory '%s'"+
 					" from failed to staging folder", dir.Name())
 			}
+			cnt++
 		} else {
 			break
 		}


### PR DESCRIPTION
This fixes the bug where I was not incrementing the cnt and thus the if condition wouldn't ever fail. Added one more bug fix, where I was calling the wrong function  for refreshing cache.