### PR TITLE
[XAPID-854] Listen to Apid shutdown, register callback and do a clean shutdown by closing open files

### DIFF
--- a/buffering_manager.go
+++ b/buffering_manager.go
@@ -17,10 +17,14 @@ const fileExtension = ".txt.gz"
 // Channel where analytics records are buffered before being dumped to a
 // file as write to file should not performed in the Http Thread
 var internalBuffer chan axRecords
+// channel to indicate that internalBuffer channel is closed
+var doneInternalBufferChan chan bool
 
 // Channel where close bucket event is published i.e. when a bucket
 // is ready to be closed based on collection interval
 var closeBucketEvent chan bucket
+// channel to indicate that closeBucketEvent channel is closed
+var doneClosebucketChan chan bool
 
 // Map from timestampt to bucket
 var bucketMap map[int64]bucket
@@ -47,6 +51,8 @@ func initBufferingManager() {
 	internalBuffer = make(chan axRecords,
 		config.GetInt(analyticsBufferChannelSize))
 	closeBucketEvent = make(chan bucket)
+	doneInternalBufferChan = make(chan bool)
+	doneClosebucketChan = make(chan bool)
 
 	bucketMaplock.Lock()
 	bucketMap = make(map[int64]bucket)
@@ -55,38 +61,53 @@ func initBufferingManager() {
 	// Keep polling the internal buffer for new messages
 	go func() {
 		for {
-			records := <-internalBuffer
-			err := save(records)
-			if err != nil {
-				log.Errorf("Could not save %d messages to file"+
-					" due to: %v", len(records.Records), err)
+			records, more := <-internalBuffer
+			if more {
+				err := save(records)
+				if err != nil {
+					log.Errorf("Could not save %d messages to file"+
+						" due to: %v", len(records.Records), err)
+				}
+			} else {
+				// indicates a close signal was sent on the channel
+				log.Debugf("Closing channel internal buffer")
+				doneInternalBufferChan <- true
+				return
 			}
+
 		}
 	}()
 
 	// Keep polling the closeEvent channel to see if bucket is ready to be closed
 	go func() {
 		for {
-			bucket := <-closeBucketEvent
-			log.Debugf("Close Event received for bucket: %s",
-				bucket.DirName)
+			bucket, more := <-closeBucketEvent
+			if more {
+				log.Debugf("Close Event received for bucket: %s",
+					bucket.DirName)
 
-			// close open file
-			closeGzipFile(bucket.FileWriter)
+				// close open file
+				closeGzipFile(bucket.FileWriter)
 
-			dirToBeClosed := filepath.Join(localAnalyticsTempDir, bucket.DirName)
-			stagingPath := filepath.Join(localAnalyticsStagingDir, bucket.DirName)
-			// close files in tmp folder and move directory to
-			// staging to indicate its ready for upload
-			err := os.Rename(dirToBeClosed, stagingPath)
-			if err != nil {
-				log.Errorf("Cannot move directory '%s' from"+
-					" tmp to staging folder due to '%s", bucket.DirName, err)
+				dirToBeClosed := filepath.Join(localAnalyticsTempDir, bucket.DirName)
+				stagingPath := filepath.Join(localAnalyticsStagingDir, bucket.DirName)
+				// close files in tmp folder and move directory to
+				// staging to indicate its ready for upload
+				err := os.Rename(dirToBeClosed, stagingPath)
+				if err != nil {
+					log.Errorf("Cannot move directory '%s' from"+
+						" tmp to staging folder due to '%s", bucket.DirName, err)
+				} else {
+					// Remove bucket from bucket map once its closed successfully
+					bucketMaplock.Lock()
+					delete(bucketMap, bucket.keyTS)
+					bucketMaplock.Unlock()
+				}
 			} else {
-				// Remove bucket from bucket map once its closed successfully
-				bucketMaplock.Lock()
-				delete(bucketMap, bucket.keyTS)
-				bucketMaplock.Unlock()
+				// indicates a close signal was sent on the channel
+				log.Debugf("Closing channel close bucketevent")
+				doneClosebucketChan <- true
+				return
 			}
 		}
 	}()

--- a/buffering_manager.go
+++ b/buffering_manager.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 	"sync"
+	"time"
 )
 
 const fileExtension = ".txt.gz"
@@ -30,7 +30,7 @@ var bucketMap map[int64]bucket
 var bucketMaplock = sync.RWMutex{}
 
 type bucket struct {
-	keyTS int64
+	keyTS   int64
 	DirName string
 	// We need file handle and writer to close the file
 	FileWriter fileWriter
@@ -51,7 +51,6 @@ func initBufferingManager() {
 	bucketMaplock.Lock()
 	bucketMap = make(map[int64]bucket)
 	bucketMaplock.Unlock()
-
 
 	// Keep polling the internal buffer for new messages
 	go func() {
@@ -81,14 +80,14 @@ func initBufferingManager() {
 			// staging to indicate its ready for upload
 			err := os.Rename(dirToBeClosed, stagingPath)
 			if err != nil {
-				log.Errorf("Cannot move directory '%s' from" +
+				log.Errorf("Cannot move directory '%s' from"+
 					" tmp to staging folder due to '%s", bucket.DirName, err)
+			} else {
+				// Remove bucket from bucket map once its closed successfully
+				bucketMaplock.Lock()
+				delete(bucketMap, bucket.keyTS)
+				bucketMaplock.Unlock()
 			}
-
-			// Remove bucket from bucket map once its closed successfully
-			bucketMaplock.Lock()
-			delete(bucketMap, bucket.keyTS)
-			bucketMaplock.Unlock()
 		}
 	}()
 }

--- a/buffering_manager_test.go
+++ b/buffering_manager_test.go
@@ -118,7 +118,7 @@ var _ = Describe("test closeBucketChannel()", func() {
 			fw, e := createGzipFile(completeFilePath)
 			Expect(e).ShouldNot(HaveOccurred())
 
-			bucket := bucket{DirName: dirName, FileWriter: fw}
+			bucket := bucket{keyTS: 112312, DirName: dirName, FileWriter: fw}
 			closeBucketEvent <- bucket
 
 			// wait for it to close dir and move to staging

--- a/init.go
+++ b/init.go
@@ -146,7 +146,7 @@ func initPlugin(services apid.Services) (apid.PluginData, error) {
 	// Create a listener for shutdown event and register callback
 	h := func(event apid.Event) {
 		log.Infof("Received ApidShutdown event. %v", event)
-		shutdownPlugin();
+		shutdownPlugin()
 		return
 	}
 	log.Infof("registered listener for shutdown event")
@@ -228,10 +228,10 @@ func shutdownPlugin() {
 		if err != nil {
 			log.Errorf("Cannot move directory '%s' from"+
 				" tmp to staging folder due to '%s", bucket.DirName, err)
+		} else {
+			bucketMaplock.Lock()
+			delete(bucketMap, bucket.keyTS)
+			bucketMaplock.Unlock()
 		}
-
-		bucketMaplock.Lock()
-		delete(bucketMap, bucket.keyTS)
-		bucketMaplock.Unlock()
 	}
 }

--- a/upload_manager.go
+++ b/upload_manager.go
@@ -47,6 +47,8 @@ func initUploadManager() {
 					handleUploadDirStatus(file, status)
 					if status {
 						uploadedDirCnt++
+						log.Infof("Successfully uploaded: %s",
+							file.Name())
 					}
 				}
 			}

--- a/upload_manager.go
+++ b/upload_manager.go
@@ -47,7 +47,7 @@ func initUploadManager() {
 					handleUploadDirStatus(file, status)
 					if status {
 						uploadedDirCnt++
-						log.Infof("Successfully uploaded: %s",
+						log.Debugf("Successfully uploaded: %s",
 							file.Name())
 					}
 				}


### PR DESCRIPTION
- On initialization create a listener for apidShutdownEvent and register a callback
- On event reception, the plugin closes all open files and moves it to staging.
- since bucketMap can be written and read from simultaneously now, Added a RWmutex to acquire locks while accessing the map